### PR TITLE
Add gradle testing

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,44 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="src" path="comodo2/src"/>
-	<classpathentry kind="lib" path="libs/com.google.guava_21.0.0.v20170206-1425.jar"/>
-	<classpathentry kind="lib" path="libs/com.google.inject_3.0.0.v201312141243.jar"/>
-	<classpathentry kind="lib" path="libs/javax.inject_1.0.0.v20091030.jar"/>
-	<classpathentry kind="lib" path="libs/org.antlr.runtime_3.2.0.v201101311130.jar"/>
-	<classpathentry kind="lib" path="libs/org.apache.commons.logging_1.2.0.v20180409-1502.jar"/>
-	<classpathentry kind="lib" path="libs/org.apache.log4j_1.2.15.v201012070815.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.core.contenttype_3.7.300.v20190215-2048.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.core.jobs_3.10.300.v20190215-2048.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.core.runtime_3.15.200.v20190301-1641.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.emf.common_2.15.0.v20181220-0846.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.emf.ecore_2.17.0.v20190116-0940.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.emf.ecore.xmi_2.15.0.v20180706-1146.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.emf.mapping.ecore2xml_2.11.0.v20180706-1146.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.emf.mwe.core_1.4.0.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.emf.mwe.utils_1.4.0.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.emf.mwe2.language_2.10.0.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.emf.mwe2.launch_2.10.0.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.emf.mwe2.runtime_2.10.0.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.equinox.app_1.4.100.v20190215-2139.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.equinox.common_3.10.300.v20190218-2100.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.equinox.preferences_3.7.300.v20190218-2100.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.equinox.registry_3.8.300.v20190218-2100.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.osgi_3.13.300.v20190218-1622.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.osgi.compatibility.state_1.1.400.v20190208-1533.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.uml2.common_2.5.0.v20181203-1331.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.uml2.types_2.5.0.v20181203-1331.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.uml2.uml_5.5.0.v20181203-1331.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.uml2.uml.profile.standard_1.5.0.v20181203-1331.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.uml2.uml.resources_5.5.0.v20181203-1331.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.xtend.lib_2.17.1.v20190401-1111.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.xtend.lib.macro_2.17.1.v20190401-1111.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.xtext_2.17.1.v20190402-0537.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.xtext.common.types_2.17.1.v20190402-0745.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.xtext.util_2.17.1.v20190402-0537.jar"/>
-	<classpathentry kind="lib" path="libs/org.eclipse.xtext.xbase.lib_2.17.1.v20190401-1111.jar"/>
-	<classpathentry kind="lib" path="libs/org.objectweb.asm_7.0.0.v20181030-2244.jar"/>
-	<classpathentry kind="lib" path="libs/ST-4.3.1.jar"/>
-	<classpathentry kind="lib" path="libs/commons-cli-1.4.jar"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="src" output="bin/main" path="comodo2/src">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cli
 
 # Ignore Gradle project-specific cache directory
 .gradle
+test/gradle-testgen

--- a/build.gradle
+++ b/build.gradle
@@ -67,8 +67,64 @@ jar {
             it.isDirectory() ? it : zipTree(it)
         }
     } {exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'}
-    // from(sourceSets.main.output.resourcesDir) {
-    //     include '**/*'
-    //     into('resources')
-    // }
+}
+
+
+
+// #################### TESTING ########################
+
+// The testing strategy is: each target is executed on a set of models in the execute<name>Target. 
+// The output is then compared in test<name>Target with the reference output, usually stored under test/<name>/ref.
+// RESULTS_MAPPING is used to store the results of the tests.
+
+ext.TEST_OUTPUT_PATH = "./test/gradle-testgen"
+ext.RESULTS_MAPPING = [:]
+
+// This function defines tasks that execute the target on the test models and compares the output with the reference output
+def defineTargetTestingTask(String taskName, String targetType, String inputFilePath, String modelName, String expectedOutputPath, String extraArgs = "") {
+  task("execute${taskName}Target", type: Exec) {
+    dependsOn build
+    group = "Execution"
+    description = "Run the ${targetType} target on the test models (${modelName})"
+    commandLine "java", "-classpath", sourceSets.main.runtimeClasspath.getAsPath(), mainClassName
+    args "-i", inputFilePath, "-o", "${TEST_OUTPUT_PATH}/${taskName}", "-t", targetType, "-m", modelName, "-a", extraArgs
+  }
+
+  task("test${taskName}Target", type: Exec) {
+    dependsOn "execute${taskName}Target"
+    group = "DiffTesting"
+    description = "Test the ${targetType} target by comparing its output with the reference output."
+    def outputFilename = "${TEST_OUTPUT_PATH}/${taskName}.difflog"
+    standardOutput = new FileOutputStream(outputFilename)
+    commandLine "diff", "-rb", "${TEST_OUTPUT_PATH}/${taskName}", "${expectedOutputPath}"
+    ignoreExitValue = true
+    doLast {
+        def output = new FileInputStream(outputFilename).text.trim()
+        if (output) {
+            println "[FAIL] Test failure: the generated code is different from the reference code. Please check the diff in ${outputFilename}."
+            RESULTS_MAPPING.put(taskName, "FAIL")
+        } else {
+            RESULTS_MAPPING.put(taskName, "PASS")
+            println "[PASS] Test succeeded."
+        }
+    }
+  }
+}
+
+// Defining test tasks
+defineTargetTestingTask("QPC-C", "QPC-C", "./test/qpc/model/qpc-test-model/qpc-test-model.uml", "BlinkyChoice", "./test/qpc/ref")
+defineTargetTestingTask("ELT-RAD1", "ELT-RAD", "./test/elt/model/hello/EELT_ICS_ApplicationFramework.uml", "hellomalif hellomal", "./test/elt/ref/hello", "-ndgALL")
+defineTargetTestingTask("ELT-RAD2", "ELT-RAD", "./test/elt/model/hello/EELT_ICS_ApplicationFramework.uml", "hellomalif2 externalif2 hellomal2", "./test/elt/ref/hello2", "-ndgALL")
+
+// Execute all tests and returns results
+task testAll {
+    dependsOn tasks.matching { it.group == "DiffTesting" }
+    doLast{
+        println "${RESULTS_MAPPING.size()} tests executed. Results (PASS/FAIL) by target: ${RESULTS_MAPPING}"
+        if (RESULTS_MAPPING.values().any { it == "FAIL" }) {
+            throw new GradleException("[FAIL] At least one test failed. See logs above and in ${TEST_OUTPUT_PATH}/*.difflog for details.")
+        } else {
+            println "[PASS] All tests succeeded."
+        }
+    }
 }


### PR DESCRIPTION
Addresses https://github.com/Open-MBEE/Comodo/issues/10.

This adds Gradle tasks to perform testing automatically. We currently have 3 suites of testing, one for QPC-C and two for ELT-RAD. I have basically replicated what was done in the build.xml, but with Gradle. New target/test pairs can easily be added with the function defined in build.gradle.

Usage: `./gradlew testAll` to test all targets, or `./gradlew testQPC-CTarget` for a single target.