### PR TITLE
Adding GitHub workflow for testing

### DIFF
--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -1,0 +1,23 @@
+name: Gradle Build and Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      with:
+        arguments: testAll

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ def defineTargetTestingTask(String taskName, String targetType, String inputFile
     dependsOn "execute${taskName}Target"
     group = "DiffTesting"
     description = "Test the ${targetType} target by comparing its output with the reference output."
+    new File("${TEST_OUTPUT_PATH}").mkdirs()
     def outputFilename = "${TEST_OUTPUT_PATH}/${taskName}.difflog"
     standardOutput = new FileOutputStream(outputFilename)
     commandLine "diff", "-rb", "${TEST_OUTPUT_PATH}/${taskName}", "${expectedOutputPath}"


### PR DESCRIPTION
Adresses https://github.com/Open-MBEE/Comodo/issues/11

This adds a workflow to run the Gradle `testAll` target. This builds the application, and runs a set of test as defined by Gradle. Also adding a line to the task definition to create the output directory if it does not exist already, as I've realized this can cause issues on some platforms.