### PR TITLE
Bump Gradle action to v2

### DIFF
--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -18,6 +18,6 @@ jobs:
         distribution: 'temurin'
 
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: testAll


### PR DESCRIPTION
The action was introduced locked a specific release which I did not realize was a little old (it had been automatically populated by GitHub). Changing to using "v2" which should use the latest v2.X release. 
This has resolved the deprecation warnings that were mentioned in https://github.com/Open-MBEE/Comodo/pull/17